### PR TITLE
v1.3.1: 3 parse error fixes

### DIFF
--- a/addons/debug_console/core/extensions/DnsCommands.gd
+++ b/addons/debug_console/core/extensions/DnsCommands.gd
@@ -93,8 +93,10 @@ func _cmd_dns_interfaces(_args: Array, _piped_input: String = "") -> String:
 	return "\n".join(lines)
 
 func _cmd_dns_cache_clear(_args: Array, _piped_input: String = "") -> String:
-	IP.clear_cached_hostnames()
-	return _format_success("Cleared cached hostname resolutions")
+	# IP.clear_cached_hostnames() does not exist in Godot 4.6; the singular
+	# IP.clear_cached_hostname(host) exists but requires a host arg. We treat
+	# this command as a no-op with a helpful message rather than erroring.
+	return _format_success("DNS cache reset request acknowledged (Godot has no bulk clear; cache will rotate naturally)")
 
 #endregion
 

--- a/addons/debug_console/core/extensions/ScriptDiffCommands.gd
+++ b/addons/debug_console/core/extensions/ScriptDiffCommands.gd
@@ -92,10 +92,10 @@ func _cmd_script_diff_func(args: Array, piped_input: String = "") -> String:
 	var func_a: String = sel_a[1]
 	var func_b: String = sel_b[1]
 
-	var src_a := _read_file(path_a)
+	var src_a: Variant = _read_file(path_a)
 	if src_a == null:
 		return _format_error("Cannot read: %s" % path_a)
-	var src_b := _read_file(path_b)
+	var src_b: Variant = _read_file(path_b)
 	if src_b == null:
 		return _format_error("Cannot read: %s" % path_b)
 
@@ -125,10 +125,10 @@ func _cmd_script_blame(args: Array, piped_input: String = "") -> String:
 	if not FileAccess.file_exists(path):
 		return _format_error("File not found: %s" % path)
 
-	var src := _read_file(path)
+	var src: Variant = _read_file(path)
 	if src == null:
 		return _format_error("Cannot read: %s" % path)
-	var lines := src.split("\n", true)
+	var lines: PackedStringArray = str(src).split("\n", true)
 	if line_no > lines.size():
 		return _format_error("Line %d out of range (file has %d lines)" % [line_no, lines.size()])
 
@@ -236,10 +236,10 @@ func _cmd_script_revert(args: Array, piped_input: String = "") -> String:
 #region Diff core
 
 func _diff_files(path_a: String, path_b: String) -> String:
-	var src_a := _read_file(path_a)
+	var src_a: Variant = _read_file(path_a)
 	if src_a == null:
 		return _format_error("Cannot read: %s" % path_a)
-	var src_b := _read_file(path_b)
+	var src_b: Variant = _read_file(path_b)
 	if src_b == null:
 		return _format_error("Cannot read: %s" % path_b)
 	return _build_diff(src_a, src_b, path_a, path_b)
@@ -428,7 +428,7 @@ func _read_file(path: String) -> Variant:
 func _snapshot(path: String) -> bool:
 	if path.is_empty() or not FileAccess.file_exists(path):
 		return false
-	var content := _read_file(path)
+	var content: Variant = _read_file(path)
 	if content == null:
 		return false
 	var entries: Array = _history.get(path, []) as Array

--- a/addons/debug_console/core/extensions/SessionCommands.gd
+++ b/addons/debug_console/core/extensions/SessionCommands.gd
@@ -94,7 +94,7 @@ func _cmd_session_load(args: Array, _piped_input: String = "") -> String:
 	if name.is_empty():
 		return _format_error("Invalid session name: %s" % str(args[0]))
 	var path := _path_for(name)
-	var bundle_or_err := _read_json(path)
+	var bundle_or_err: Variant = _read_json(path)
 	if bundle_or_err is String:
 		return _format_error(bundle_or_err)
 	if not (bundle_or_err is Dictionary):
@@ -207,10 +207,10 @@ func _cmd_session_diff(args: Array, _piped_input: String = "") -> String:
 	var name_b := _sanitize_name(str(args[1]))
 	if name_a.is_empty() or name_b.is_empty():
 		return _format_error("Invalid session name(s): %s, %s" % [str(args[0]), str(args[1])])
-	var a_or_err := _read_json(_path_for(name_a))
+	var a_or_err: Variant = _read_json(_path_for(name_a))
 	if a_or_err is String:
 		return _format_error(a_or_err)
-	var b_or_err := _read_json(_path_for(name_b))
+	var b_or_err: Variant = _read_json(_path_for(name_b))
 	if b_or_err is String:
 		return _format_error(b_or_err)
 	if not (a_or_err is Dictionary) or not (b_or_err is Dictionary):
@@ -672,7 +672,7 @@ func _peek_meta(path: String) -> Dictionary:
 		"timestamp": 0, "iso_time": "",
 		"history": 0, "aliases": 0, "pins": 0, "repl_vars": 0, "watches": 0,
 	}
-	var parsed := _read_json(path)
+	var parsed: Variant = _read_json(path)
 	if not (parsed is Dictionary):
 		return out
 	var d: Dictionary = parsed

--- a/addons/debug_console/plugin.cfg
+++ b/addons/debug_console/plugin.cfg
@@ -2,6 +2,6 @@
 name="Debug Console"
 description="Debug console for both editor and game runtime"
 author="Abdulrahman Al-Taweel"
-version="1.2.0"
+version="1.3.1"
 script="plugin.gd"
 icon="res://addons/debug_console/icons/console_icon.svg"


### PR DESCRIPTION
Parse errors found post-merge:
- DnsCommands.gd:96 - IP.clear_cached_hostnames() does not exist in Godot 4.6
- ScriptDiffCommands.gd: 6 'var x := _read_file(...)' sites where _read_file returns Variant
- SessionCommands.gd: 4 'var x := _read_json(...)' sites with same Variant inference issue

plugin.cfg bumped to 1.3.1.

Tests: 319/319 PASS. Editor parse errors: 0.